### PR TITLE
Skip angle unit checks if value is 0

### DIFF
--- a/lib/css/values/validate.js
+++ b/lib/css/values/validate.js
@@ -37,39 +37,45 @@ exports.angle = function () {
 		var a = +matches[1];
 		var unit = matches[2];
 		var max = null;
-
-		switch (unit) {
-			case 'deg':
-				max = 360;
-				break;
-
-			case 'grad':
-				max = 400;
-				break;
-
-			case 'rad':
-				max = 2 * Math.PI;
-				break;
-
-			case 'turn':
-				max = 1;
-				break;
-
-			default:
-				throw new Error('Unhandled angle unit: ' + token.getUnit());
-		}
-
-		if (a < 0 || a >= max) {
+		
+		if (!unit && a == 0) {
 			var warningToken = token.clone();
-			this.addWarning('angle', warningToken);
+			this.addWarning('invalid-value', warningToken);
 		}
-
-		while (a < 0) {
-			a += max;
-		}
-
-		while (a >= max) {
-			a -= max;
+		else {
+			switch (unit) {
+				case 'deg':
+					max = 360;
+					break;
+	
+				case 'grad':
+					max = 400;
+					break;
+	
+				case 'rad':
+					max = 2 * Math.PI;
+					break;
+	
+				case 'turn':
+					max = 1;
+					break;
+	
+				default:
+					throw new Error('Unhandled angle unit: ' + token.getUnit());
+			}
+	
+			if (a < 0 || a >= max) {
+				var warningToken = token.clone();
+				this.addWarning('angle', warningToken);
+			}
+	
+			while (a < 0) {
+				a += max;
+			}
+	
+			while (a >= max) {
+				a -= max;
+			}
 		}
 
 		token.content = a.toFixed(10).replace(/\.?0+$/, '') + unit;


### PR DESCRIPTION
`addWarning` `'invalid-value'` since unit identifiers are only optional for `<length>`s and expected for `<angle>`s (http://www.w3.org/TR/css3-values/#angle-value, https://developer.mozilla.org/en-US/docs/Web/CSS/angle), but don't throw an error.
